### PR TITLE
Don't move window when dragging a split.

### DIFF
--- a/addons/imguidock/imguidock.cpp
+++ b/addons/imguidock/imguidock.cpp
@@ -374,6 +374,7 @@ struct DockContext
 
             if (IsItemHovered()) {
                 SetMouseCursor(cursor);
+                SetHoveredID(GImGui->CurrentWindow->DC.LastItemId);
             }
             
             if (IsItemHovered() && IsMouseClicked(0))


### PR DESCRIPTION
Don't move window when dragging a split. You can see this bug in the `main.html` HTML demo: click the `ImGui Dock` button, then drag the horizontal splitter vertically in the resulting window. I couldn't get the demo code building in Windows, but this fix did fix it in my test code...

(Because the splitter ends up behind everything else, the hovered ID needs to be updated manually. The splitter's invisible button's call to `ImGui::ItemHoverable` ends up bailing out early from the `g.HoveredWindow != g.CurrentWindow` check, so the hovered ID is never updated there. If there's no hovered ID by the time of `ImGui::EndFrame`, there appears to be no widget under the cursor, and dragging the mouse may then move the window.)