### PR TITLE
Don't deserialize empty names as "\n".

### DIFF
--- a/addons/imguidock/imguidock.cpp
+++ b/addons/imguidock/imguidock.cpp
@@ -1360,6 +1360,10 @@ void DockDebugWindow()
 		m_docks[P.curIndex]->invalid_frames = 0;
 	    }
 	    else if (strcmp(name,"label")==0) {
+            if (strcmp((const char*)pValue, "\n") == 0) {
+                // ??? - bug in the serializer, I suppose?
+                pValue = (void*)"";
+            }
 		    m_docks[P.curIndex]->label = ImStrdup((const char*) pValue);
 		    m_docks[P.curIndex]->id = ImHash(m_docks[P.curIndex]->label, 0);
 	    }


### PR DESCRIPTION
I assume this is a bug in the serializer? - anyway, I don't have a good way of testing anything other than the dock code, so I'm afraid I decided to go for the quick and dirty dock-specific fix here.

Thanks,

--Tom