### PR TITLE
Turn imguivariouscontrols to yes_addon when NO_IMGUI_ADDONS is defined

### DIFF
--- a/addons/imgui_user.h
+++ b/addons/imgui_user.h
@@ -73,6 +73,9 @@
 #   if (!defined(YES_IMGUIHELPER) && !defined(NO_IMGUIHELPER))
 #       define NO_IMGUIHELPER
 #   endif //YES_IMGUIHELPER
+#   if (!defined(YES_IMGUIVARIOUSCONTROLS) && !defined(NO_IMGUIVARIOUSCONTROLS))
+#       define NO_IMGUIVARIOUSCONTROLS
+#   endif //YES_IMGUIVARIOUSCONTROLS
 #endif // NO_IMGUI_ADDONS
 
 // Defining a custom placement new() with a dummy parameter allows us to bypass including <new> which on some platforms complains when user has disabled exceptions.


### PR DESCRIPTION
If `NO_IMGUI_ADDONS` was defined, `addons/imgui_user.h` wasn't
turning `imguivariouscontrols` from "normal" to "yes_addon".

This pull request fixes #39.