### PR TITLE
Make code build with IMGUI_DISABLE_OBSOLETE_FUNCTIONS

### DIFF
--- a/addons/imguidock/imguidock.cpp
+++ b/addons/imguidock/imguidock.cpp
@@ -594,8 +594,6 @@ struct DockContext
 
 	Begin("##Overlay",
               NULL,
-	      ImVec2(0, 0),
-	      0.f,
               ImGuiWindowFlags_Tooltip | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove |
               ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings |
               ImGuiWindowFlags_AlwaysAutoResize);

--- a/addons/imguitoolbar/imguitoolbar.h
+++ b/addons/imguitoolbar/imguitoolbar.h
@@ -187,7 +187,13 @@ public:
         const float oldFrameBorderSize = Style.FrameBorderSize;Style.FrameBorderSize=0.f;
         static const ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar|ImGuiWindowFlags_NoResize|ImGuiWindowFlags_NoMove|ImGuiWindowFlags_NoScrollbar|ImGuiWindowFlags_NoScrollWithMouse|
                 ImGuiWindowFlags_NoCollapse|ImGuiWindowFlags_AlwaysAutoResize|ImGuiWindowFlags_NoSavedSettings/*|ImGuiWindowFlags_Tooltip*/;
-        const bool dontSkip = inWindowMode || ImGui::Begin(name,NULL,toolbarWindowSize,0,flags);
+        bool dontSkip;
+        if (inWindowMode) {
+            dontSkip = true;
+        } else {
+            ImGui::SetNextWindowSize(toolbarWindowSize, ImGuiCond_FirstUseEver);
+            dontSkip = ImGui::Begin(name,NULL,flags);
+        }
         if (dontSkip){                        
             ImGui::PushStyleColor(ImGuiCol_Button,ImVec4(0,0,0,0));      // Hack not needed in previous ImGui versions: the bg color of the image button should be defined inside ImGui::ImageButton(...). (see below)
             bool noItemHovered = true;float nextSpacingAmount = 0;float currentWidth=Style.WindowPadding.x;const float windowWidth = ImGui::GetWindowWidth();


### PR DESCRIPTION
`ImGui::Begin` has different overloads when `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` is defined. This seemed like an easy fix for imguidock.cpp so I fixed that. I also fixed up imguitoolbar.h, though my code doesn't use that, and I'm working on Windows at the moment, so while it does build as part of my project, it's untested...

Anyway, even if you don't want this specific PR: it would be useful for the addons code to build with `IMGUI_DISABLE_OBSOLETE_FUNCTIONS`, especially when it looks like it wouldn't be all that much work.

Thanks,

--Tom
