### PR TITLE
Add optional default_pos parameter to BeginDock.

### DIFF
--- a/addons/imguidock/imguidock.cpp
+++ b/addons/imguidock/imguidock.cpp
@@ -265,7 +265,7 @@ struct DockContext
         m_docks.clear();
     }
 
-    Dock& getDock(const char* label, bool opened, const ImVec2& default_size)
+    Dock& getDock(const char* label, bool opened, const ImVec2& default_size, const ImVec2& default_pos)
     {
         ImU32 id = ImHash(label, 0);
 	for (int i = 0,iSz = m_docks.size(); i < iSz; ++i)
@@ -281,7 +281,7 @@ struct DockContext
         new_dock->id = id;
         new_dock->setActive();
         new_dock->status = (m_docks.size() == 1)?Status_Docked:Status_Float;
-        new_dock->pos = ImVec2(0, 0);
+        new_dock->pos = default_pos;
 	//new_dock->size = GetIO().DisplaySize;
 	new_dock->size.x = default_size.x < 0 ? GetIO().DisplaySize.x : default_size.x;
 	new_dock->size.y = default_size.y < 0 ? GetIO().DisplaySize.y : default_size.y;
@@ -1081,11 +1081,11 @@ struct DockContext
 	}
     }
 
-    bool begin(const char* label, bool* opened, ImGuiWindowFlags extra_flags, const ImVec2& default_size)
+    bool begin(const char* label, bool* opened, ImGuiWindowFlags extra_flags, const ImVec2& default_size, const ImVec2& default_pos)
     {
 	IM_ASSERT(!m_is_begin_open);
 	m_is_begin_open = true;
-	Dock& dock = getDock(label, !opened || *opened, default_size);
+	Dock& dock = getDock(label, !opened || *opened, default_size, default_pos);
 	if (dock.last_frame != 0 && m_last_frame != ImGui::GetFrameCount())
 	{
 	    cleanDocks();
@@ -1344,10 +1344,10 @@ void SetDockActive()
 }
 
 
-bool BeginDock(const char* label, bool* opened, ImGuiWindowFlags extra_flags, const ImVec2& default_size)
+bool BeginDock(const char* label, bool* opened, ImGuiWindowFlags extra_flags, const ImVec2& default_size, const ImVec2& default_pos)
 {
     IM_ASSERT(g_dock != NULL && "No current context. Did you call ImGui::CreateDockContext() or ImGui::SetCurrentDockContext()?");
-    return g_dock->begin(label, opened, extra_flags, default_size);
+    return g_dock->begin(label, opened, extra_flags, default_size, default_pos);
 }
 
 

--- a/addons/imguidock/imguidock.h
+++ b/addons/imguidock/imguidock.h
@@ -124,7 +124,7 @@ IMGUI_API void SetNextDock(ImGuiDockSlot slot);
 // When the floating/undocked window is manually resized, the last modified window size is kept (and the passed argument is ignored).
 // If 'default_size' is negative, any manual resizing (of the floating window) will be lost when the window is re-docked.
 // Please note that if you LoadDock(...) the last saved value will be used (so 'default_size' can still be ignored).
-IMGUI_API bool BeginDock(const char* label, bool* opened = NULL, ImGuiWindowFlags extra_flags = 0, const ImVec2& default_size = ImVec2(0,0));
+IMGUI_API bool BeginDock(const char* label, bool* opened = NULL, ImGuiWindowFlags extra_flags = 0, const ImVec2& default_size = ImVec2(0,0), const ImVec2& default_pos = ImVec2(0,0));
 IMGUI_API void EndDock();
 IMGUI_API void SetDockActive();
 IMGUI_API void DockDebugWindow();


### PR DESCRIPTION
I got annoyed at dock windows opening in windowed mode at (0,0), because they'd then appear on top of the menu bar. With this extra optional `BeginDock` parameter, I can make them open at (10,30) instead.

(Interestingly, there doesn't appear to be any way to query the exact dear imgui menu bar height. This is noted only for the record... feels like fixing this would be out of scope for this fork. And it's hardly a major problem anyway.)

When not specified, the window will open at (0,0) as before.

--Tom
